### PR TITLE
Handle intial webhook gracefully

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -64,8 +64,12 @@ def github_demo_webhook():
     if not validate_github_webhook_signature(
         flask.request.data, flask.request.headers.get("X-Hub-Signature")
     ):
-        return flask.jsonify({"messages": "Invalid secret"}, 403)
+        return flask.jsonify({"message": "Invalid secret"}, 403)
 
+    # Say hi to github when we do the initial setup.
+    if flask.request.headers.get("X-GitHub-Event") == "ping":
+        return flask.jsonify({"message": "Hi Github!"}, 200)
+    
     payload = flask.request.json
     action = payload["action"]
     pull_request = payload["number"]
@@ -75,6 +79,7 @@ def github_demo_webhook():
 
     issue = ghub.issue(repo_owner, repo_name, pull_request)
     repo = ghub.repository(repo_owner, repo_name)
+
     # Only trigger builds if PR author is a collaborator
     if not repo.is_collaborator(author):
         message = f"{author} is not a collaborator of the repo"
@@ -83,7 +88,7 @@ def github_demo_webhook():
         if action == "opened":
             issue.create_comment(message)
 
-        return flask.jsonify({"messages": message}, 403)
+        return flask.jsonify({"message": message}, 403)
 
     # Work out the remote build utl
     try:
@@ -107,4 +112,4 @@ def github_demo_webhook():
         domain = f"{repo_name.replace('.', '-')}-{pull_request}.demos.haus"
         issue.create_comment(f"Demo starting at https://{domain}")
 
-    return flask.jsonify({"messages": "Webhook handled"}, 200)
+    return flask.jsonify({"message": "Webhook handled"}, 200)

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -73,6 +73,7 @@ def github_demo_webhook():
     payload = flask.request.json
     action = payload["action"]
     pull_request = payload["number"]
+    pull_request_url = payload["pull_request"]["html_url"]
     repo_owner = payload["repository"]["owner"]["login"]
     repo_name = payload["repository"]["name"]
     author = payload["sender"]["login"]
@@ -96,7 +97,7 @@ def github_demo_webhook():
     except KeyError:
         return flask.jsonify({"message": f"No job for PR action: {action}"}), 200
 
-    jenkins_job_params = f"token={JENKINS_TOKEN}&REPO={repo_name}&PR={pull_request}"
+    jenkins_job_params = f"token={JENKINS_TOKEN}&PR_URL={pull_request_url}"
     remote_build_url = f"http://{JENKINS_URL}/{jenkins_job}/buildWithParameters?{jenkins_job_params}"
     
     # Trigger the build in jenkins


### PR DESCRIPTION
## Done
Handle initial `ping` event by saying hello to github.

## QA

- Check out this feature branch
- Run the site using the command `./run`
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Create a channel in https://smee.io/
- `npm install --global smee-client`
- smee -u https://smee.io/(your-smee-channel-id) -t localhost:8100/hook/gh
- In this repo create a webhook pointing at `https://smee.io/<your-channel-id>` with `application/json` and the secret `fake_secret`.
- Check that you get a 200 for the intial ping event, you might not get the message(I think smee does not proxy the body back to github)

## Issue / Card

Fixes #12 
