### PR TITLE
Use original Flask-OpenID instead of Flask-OpenID-Stateless

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 canonicalwebteam.flask-base==0.9.1
 django-openid-auth==0.16
 github3.py==2.0.0
-Flask-OpenID-Stateless==1.2.6
+Flask-OpenID==1.3.0
 kubernetes==18.20.0 
 requests==2.26.0

--- a/webapp/sso.py
+++ b/webapp/sso.py
@@ -11,7 +11,9 @@ SSO_TEAM = "canonical-webmonkeys"
 
 def init_sso(app):
     open_id = OpenID(
-        stateless=True, safe_roots=[], extension_responses=[TeamsResponse]
+        store_factory=lambda: None,
+        safe_roots=[],
+        extension_responses=[TeamsResponse]
     )
 
     @app.route("/login", methods=["GET", "POST"])


### PR DESCRIPTION
## Done

- This is a copy of this PR for snapcraft.io: https://github.com/canonical-web-and-design/snapcraft.io/pull/3740
- Stop using our own fork FlaskOpenID-Stateless to use the original module.

## QA

- Check the authentication is working as usual.
