### PR TITLE
Added keepdb parameter

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -102,10 +102,10 @@ def github_demo_webhook():
         return flask.jsonify({"message": message}, 403)
 
     # Check if the db should be deleted
-    keepdb = False
+    keepdb = "false"
     for label in payload["pull_request"]["labels"]:
         if label["name"] == "keepdb":
-            keepdb = True
+            keepdb = "true"
             break
 
     # Work out the remote build url

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -102,9 +102,10 @@ def github_demo_webhook():
         return flask.jsonify({"message": message}, 403)
 
     # Check if the db should be deleted
-    keepdb = (
-        "true" if "keepdb" in payload["pull_request"]["labels"] else "false"
-    )
+    for label in payload["pull_request"]["labels"]:
+        if label["name"] == "keepdb":
+            keepdb = True
+            break
 
     # Work out the remote build url
     try:

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -41,8 +41,8 @@ init_sso(app)
 def get_jenkins_job(action):
     # To be changed after QA
     return {
-        "opened": "webteam/job/start-demo-test",
-        "synchronize": "webteam/job/start-demo-test",
+        "opened": "webteam/job/start-demo",
+        "synchronize": "webteam/job/start-demo",
         "closed": "webteam/job/stop-demo",
     }[action]
 

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -102,6 +102,7 @@ def github_demo_webhook():
         return flask.jsonify({"message": message}, 403)
 
     # Check if the db should be deleted
+    keepdb = False
     for label in payload["pull_request"]["labels"]:
         if label["name"] == "keepdb":
             keepdb = True

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -39,9 +39,10 @@ init_sso(app)
 
 
 def get_jenkins_job(action):
+    # To be changed after QA
     return {
-        "opened": "webteam/job/start-demo",
-        "synchronize": "webteam/job/start-demo",
+        "opened": "webteam/job/start-demo-test",
+        "synchronize": "webteam/job/start-demo-test",
         "closed": "webteam/job/stop-demo",
     }[action]
 
@@ -100,6 +101,11 @@ def github_demo_webhook():
 
         return flask.jsonify({"message": message}, 403)
 
+    # Check if the db should be deleted
+    keepdb = (
+        "true" if "keepdb" in payload["pull_request"]["labels"] else "false"
+    )
+
     # Work out the remote build url
     try:
         jenkins_job = get_jenkins_job(action)
@@ -109,10 +115,10 @@ def github_demo_webhook():
             200,
         )
 
-    jenkins_job_params = f"token={JENKINS_TOKEN}&PR_URL={pull_request_url}"
-    remote_build_url = (
-        f"http://{JENKINS_URL}/{jenkins_job}/buildWithParameters?{jenkins_job_params}"
+    jenkins_job_params = (
+        f"token={JENKINS_TOKEN}&PR_URL={pull_request_url}&KEEP_DB={keepdb}"
     )
+    remote_build_url = f"http://{JENKINS_URL}/{jenkins_job}/buildWithParameters?{jenkins_job_params}"
     job_id = ""
 
     # Trigger the build in jenkins
@@ -128,7 +134,9 @@ def github_demo_webhook():
 
     # If the PR was opened post the the link to the demo
     if action == "opened":
-        demo_url = f"https://{repo_name.replace('.', '-')}-{pull_request}.demos.haus"
+        demo_url = (
+            f"https://{repo_name.replace('.', '-')}-{pull_request}.demos.haus"
+        )
         jenkins_url = f"{JENKINS_PUBLIC_URL}/{jenkins_job}/{job_id}"
 
         comment = f"### [<img src='https://assets.ubuntu.com/v1/6baef514-ubuntu-circle-of-friends-large.svg' height=32 width=32> Demo</img>]({demo_url})\n"


### PR DESCRIPTION
## Done

Made it possible to reuse a demo's database

## QA

- Create a PR on [masterclasses.canonical.com](https://github.com/canonical/masterclasses.canonical.com)
- Before confirming the PR, add the label `keepdb`
- The database should not be deleted
- Remove the `keepdb` label and make a push to the repo
- The database should be deleted and recreated
- Do this at least twice to be sure the newly created database isn't modified when `keepdb` is set

## Issue / Card

Fixes [WD-7574](https://warthogs.atlassian.net/browse/WD-7574)

## Note
- Before merging to main, update the `get_jenkins_job` function to use `start-demo` instead of `start-demo-test` 

[WD-7574]: https://warthogs.atlassian.net/browse/WD-7574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ