### PR TITLE
Allow Copilot-authored PRs to trigger demo builds

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -98,7 +98,12 @@ def github_demo_webhook():
     repo = ghub.repository(repo_owner, repo_name)
 
     # Only trigger builds if PR author is a collaborator
-    allowed_bots = ["renovate[bot]", "dependabot[bot]", "github-actions[bot]"]
+    allowed_bots = [
+        "renovate[bot]",
+        "dependabot[bot]",
+        "github-actions[bot]",
+        "Copilot",
+    ]
     allowed = author in allowed_bots or repo.is_collaborator(author)
 
     if not allowed:


### PR DESCRIPTION
## Done
- Whitelisted Copilot so that `webteam-app` can generate demos for Copilot authored PRs.

## QA (has to be tested after merging)
- Create an issue on ubuntu.com describing dummy changes
- Add a comment tagging copilot to create a PR based on those changes.
- Ensure that a demos.haus link is created.

## Issue / Card
https://warthogs.atlassian.net/browse/WD-37837